### PR TITLE
Add venue search

### DIFF
--- a/src/components_react/AddVenueModal.tsx
+++ b/src/components_react/AddVenueModal.tsx
@@ -1,0 +1,366 @@
+import {
+  Building2,
+  Clock,
+  Loader2,
+  MapPin,
+  Plus,
+  Users,
+  X
+} from 'lucide-react';
+import React, { useState } from 'react';
+import { APIProvider } from '@vis.gl/react-google-maps';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Switch } from './ui/switch';
+import { VenueRequest, ServiceType, DayHours } from '../lib/api-client';
+import { PlaceAutocompleteInput } from './PlaceAutocompleteInput';
+
+interface AddVenueModalProps {
+  children: React.ReactNode;
+  onAddVenue: (venue: VenueRequest) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+const serviceTypes: ServiceType[] = ['daycare', 'boarding', 'grooming', 'walking', 'training'];
+
+const daysOfWeek = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'] as const;
+
+export function AddVenueModal({ children, onAddVenue, isSubmitting = false }: AddVenueModalProps) {
+  const [open, setOpen] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    address: '',
+    latitude: '',
+    longitude: '',
+    capacity: '',
+    slotDuration: '60',
+    services: ['daycare'] as ServiceType[],
+    operatingHours: {
+      monday: { open: true, start: '09:00', end: '18:00' },
+      tuesday: { open: true, start: '09:00', end: '18:00' },
+      wednesday: { open: true, start: '09:00', end: '18:00' },
+      thursday: { open: true, start: '09:00', end: '18:00' },
+      friday: { open: true, start: '09:00', end: '18:00' },
+      saturday: { open: false, start: '09:00', end: '18:00' },
+      sunday: { open: false, start: '09:00', end: '18:00' },
+    } as Record<typeof daysOfWeek[number], DayHours>
+  });
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handlePlaceSelect = (place: { address: string; latitude: number; longitude: number; name?: string }) => {
+    setFormData(prev => ({
+      ...prev,
+      address: place.address,
+      latitude: place.latitude.toString(),
+      longitude: place.longitude.toString(),
+      // Optionally pre-fill name if not already set
+      name: prev.name || place.name || ''
+    }));
+  };
+
+  const toggleService = (service: ServiceType) => {
+    setFormData(prev => ({
+      ...prev,
+      services: prev.services.includes(service)
+        ? prev.services.filter(s => s !== service)
+        : [...prev.services, service]
+    }));
+  };
+
+  const updateOperatingHours = (day: typeof daysOfWeek[number], field: keyof DayHours, value: string | boolean) => {
+    setFormData(prev => ({
+      ...prev,
+      operatingHours: {
+        ...prev.operatingHours,
+        [day]: {
+          ...prev.operatingHours[day],
+          [field]: value
+        }
+      }
+    }));
+  };
+
+  const handleSubmit = async () => {
+    const venueData: VenueRequest = {
+      name: formData.name,
+      address: formData.address,
+      latitude: parseFloat(formData.latitude),
+      longitude: parseFloat(formData.longitude),
+      capacity: parseInt(formData.capacity),
+      slot_duration: parseInt(formData.slotDuration),
+      services: formData.services,
+      operating_hours: formData.operatingHours
+    };
+
+    try {
+      await onAddVenue(venueData);
+      // Reset form and close modal on success
+      setOpen(false);
+      setFormData({
+        name: '',
+        address: '',
+        latitude: '',
+        longitude: '',
+        capacity: '',
+        slotDuration: '60',
+        services: ['daycare'],
+        operatingHours: {
+          monday: { open: true, start: '09:00', end: '18:00' },
+          tuesday: { open: true, start: '09:00', end: '18:00' },
+          wednesday: { open: true, start: '09:00', end: '18:00' },
+          thursday: { open: true, start: '09:00', end: '18:00' },
+          friday: { open: true, start: '09:00', end: '18:00' },
+          saturday: { open: false, start: '09:00', end: '18:00' },
+          sunday: { open: false, start: '09:00', end: '18:00' },
+        }
+      });
+    } catch (error) {
+      console.error('Error in AddVenueModal:', error);
+    }
+  };
+
+  const canSubmit = () => {
+    return (
+      formData.name.trim() !== '' &&
+      formData.address.trim() !== '' &&
+      formData.latitude !== '' &&
+      !isNaN(parseFloat(formData.latitude)) &&
+      formData.longitude !== '' &&
+      !isNaN(parseFloat(formData.longitude)) &&
+      formData.capacity !== '' &&
+      parseInt(formData.capacity) > 0 &&
+      formData.services.length > 0
+    );
+  };
+
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '';
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {children}
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Building2 className="h-5 w-5 text-primary" />
+            Add New Venue
+          </DialogTitle>
+          <DialogDescription>
+            Complete this form to add a new venue to the DogPark(ing) platform.
+          </DialogDescription>
+        </DialogHeader>
+
+        <APIProvider apiKey={apiKey}>
+          <div className="space-y-6">
+          {/* Basic Information */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Basic Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">Venue Name *</Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => handleInputChange('name', e.target.value)}
+                  placeholder="e.g. Happy Paws Downtown"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="address">Search Address (UK only) *</Label>
+                <PlaceAutocompleteInput
+                  onPlaceSelect={handlePlaceSelect}
+                  value={formData.address}
+                  placeholder="Start typing to search for an address..."
+                />
+                <p className="text-xs text-muted-foreground">
+                  Select an address from the dropdown to auto-fill coordinates
+                </p>
+              </div>
+
+              {/* Show selected coordinates as read-only badges */}
+              {formData.latitude && formData.longitude && (
+                <div className="space-y-2">
+                  <Label className="flex items-center gap-2">
+                    <MapPin className="h-4 w-4 text-primary" />
+                    Selected Location
+                  </Label>
+                  <div className="flex items-center gap-2 p-3 bg-muted/50 rounded-lg border">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-4">
+                        <div>
+                          <p className="text-xs text-muted-foreground">Latitude</p>
+                          <p className="text-sm font-mono">{parseFloat(formData.latitude).toFixed(6)}</p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Longitude</p>
+                          <p className="text-sm font-mono">{parseFloat(formData.longitude).toFixed(6)}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setFormData(prev => ({ ...prev, address: '', latitude: '', longitude: '' }))}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Capacity & Settings */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Users className="h-4 w-4" />
+                Capacity & Settings
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="capacity">Maximum Capacity *</Label>
+                  <Input
+                    id="capacity"
+                    type="number"
+                    min="1"
+                    value={formData.capacity}
+                    onChange={(e) => handleInputChange('capacity', e.target.value)}
+                    placeholder="e.g. 20"
+                  />
+                  <p className="text-xs text-muted-foreground">Max dogs at one time</p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="slotDuration">Slot Duration (minutes)</Label>
+                  <Input
+                    id="slotDuration"
+                    type="number"
+                    min="15"
+                    step="15"
+                    value={formData.slotDuration}
+                    onChange={(e) => handleInputChange('slotDuration', e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">Default: 60 minutes</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Services */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Services Offered *</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                {serviceTypes.map((service) => (
+                  <Badge
+                    key={service}
+                    variant={formData.services.includes(service) ? "default" : "outline"}
+                    className="cursor-pointer px-4 py-2"
+                    onClick={() => toggleService(service)}
+                  >
+                    {formData.services.includes(service) && (
+                      <Plus className="h-3 w-3 mr-1 rotate-45" />
+                    )}
+                    {service.charAt(0).toUpperCase() + service.slice(1)}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Operating Hours */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Operating Hours
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {daysOfWeek.map((day) => (
+                <div key={day} className="flex items-center gap-4 p-3 border rounded-lg">
+                  <div className="w-28">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        checked={formData.operatingHours[day].open}
+                        onCheckedChange={(checked) => updateOperatingHours(day, 'open', checked)}
+                      />
+                      <Label className="capitalize font-medium">{day}</Label>
+                    </div>
+                  </div>
+
+                  {formData.operatingHours[day].open ? (
+                    <div className="flex items-center gap-2 flex-1">
+                      <Input
+                        type="time"
+                        value={formData.operatingHours[day].start || '09:00'}
+                        onChange={(e) => updateOperatingHours(day, 'start', e.target.value)}
+                        className="w-32"
+                      />
+                      <span className="text-muted-foreground">to</span>
+                      <Input
+                        type="time"
+                        value={formData.operatingHours[day].end || '18:00'}
+                        onChange={(e) => updateOperatingHours(day, 'end', e.target.value)}
+                        className="w-32"
+                      />
+                    </div>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">Closed</span>
+                  )}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          {/* Submit Button */}
+          <div className="flex items-center justify-end gap-2 pt-4 border-t">
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={!canSubmit() || isSubmitting}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Adding Venue...
+                </>
+              ) : (
+                <>
+                  <Building2 className="h-4 w-4 mr-2" />
+                  Add Venue
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+        </APIProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components_react/MapView.tsx
+++ b/src/components_react/MapView.tsx
@@ -32,15 +32,15 @@ export function MapView({ onVenueSelect }: MapViewProps) {
     try {
       await createVenueMutation.mutateAsync(venue);
       addToast({
+        type: 'success',
         title: 'Success!',
-        description: 'Venue added successfully',
-        variant: 'default'
+        description: 'Venue added successfully'
       });
     } catch (error) {
       addToast({
+        type: 'error',
         title: 'Error',
-        description: error instanceof Error ? error.message : 'Failed to add venue',
-        variant: 'destructive'
+        description: error instanceof Error ? error.message : 'Failed to add venue'
       });
       throw error;
     }

--- a/src/components_react/MapView.tsx
+++ b/src/components_react/MapView.tsx
@@ -2,13 +2,16 @@ import React, { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
-import { MapPin, Clock, Users, Star, Loader2, AlertCircle } from 'lucide-react';
+import { MapPin, Clock, Users, Star, Loader2, AlertCircle, Plus } from 'lucide-react';
 import { ImageWithFallback } from './figma/ImageWithFallback';
 import { BottomDrawer } from './BottomDrawer';
 import { useIsMobile } from './ui/use-mobile';
 import { APIProvider, Map, AdvancedMarker, Pin } from '@vis.gl/react-google-maps';
-import { useVenues } from '../hooks/useApi';
+import { useVenues, useCreateVenue } from '../hooks/useApi';
 import { enrichVenues, EnrichedVenue } from '../lib/venue-enrichment';
+import { AddVenueModal } from './AddVenueModal';
+import { VenueRequest } from '../lib/api-client';
+import { useToast } from './ui/toast';
 
 interface MapViewProps {
   onVenueSelect: (venue: EnrichedVenue) => void;
@@ -17,9 +20,31 @@ interface MapViewProps {
 export function MapView({ onVenueSelect }: MapViewProps) {
   const [selectedVenue, setSelectedVenue] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { addToast } = useToast();
 
   // Fetch venues from API
   const { data: apiVenues = [], isLoading, error } = useVenues();
+
+  // Create venue mutation
+  const createVenueMutation = useCreateVenue();
+
+  const handleAddVenue = async (venue: VenueRequest) => {
+    try {
+      await createVenueMutation.mutateAsync(venue);
+      addToast({
+        title: 'Success!',
+        description: 'Venue added successfully',
+        variant: 'default'
+      });
+    } catch (error) {
+      addToast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to add venue',
+        variant: 'destructive'
+      });
+      throw error;
+    }
+  };
 
   // Default user location (London center) - in production, use geolocation API
   const userLocation = { lat: 51.5074, lng: -0.1278 };
@@ -73,6 +98,19 @@ export function MapView({ onVenueSelect }: MapViewProps) {
             ))}
           </Map>
         </APIProvider>
+
+        {/* Add Venue Button - Floating over map */}
+        <div className="absolute top-4 right-4 z-10">
+          <AddVenueModal
+            onAddVenue={handleAddVenue}
+            isSubmitting={createVenueMutation.isPending}
+          >
+            <Button size="sm" className="shadow-lg">
+              <Plus className="h-4 w-4 mr-1" />
+              Add Venue
+            </Button>
+          </AddVenueModal>
+        </div>
       </div>
     );
   };

--- a/src/components_react/PlaceAutocompleteInput.tsx
+++ b/src/components_react/PlaceAutocompleteInput.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useMapsLibrary } from '@vis.gl/react-google-maps';
+import { Input } from './ui/input';
+import { MapPin, Loader2 } from 'lucide-react';
+
+interface PlaceDetails {
+  address: string;
+  latitude: number;
+  longitude: number;
+  name?: string;
+}
+
+interface PlaceAutocompleteInputProps {
+  onPlaceSelect: (place: PlaceDetails) => void;
+  value?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function PlaceAutocompleteInput({
+  onPlaceSelect,
+  value = '',
+  placeholder = 'Search for an address...',
+  disabled = false
+}: PlaceAutocompleteInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [autocompleteService, setAutocompleteService] = useState<google.maps.places.AutocompleteService | null>(null);
+  const [placesService, setPlacesService] = useState<google.maps.places.PlacesService | null>(null);
+  const [sessionToken, setSessionToken] = useState<google.maps.places.AutocompleteSessionToken | null>(null);
+
+  // Load the Places library
+  const places = useMapsLibrary('places');
+
+  // Initialize services when Places library is loaded
+  useEffect(() => {
+    if (!places) return;
+
+    setAutocompleteService(new places.AutocompleteService());
+    setSessionToken(new places.AutocompleteSessionToken());
+
+    // Create a dummy div for PlacesService (it requires a map or div)
+    const dummyDiv = document.createElement('div');
+    setPlacesService(new places.PlacesService(dummyDiv));
+  }, [places]);
+
+  // Set up autocomplete on the input element
+  useEffect(() => {
+    if (!places || !inputRef.current) return;
+
+    const autocomplete = new places.Autocomplete(inputRef.current, {
+      componentRestrictions: { country: 'gb' }, // Restrict to UK only
+      fields: ['formatted_address', 'geometry', 'name', 'place_id'],
+      types: ['establishment', 'geocode'] // Allow both businesses and addresses
+    });
+
+    // Listen for place selection
+    autocomplete.addListener('place_changed', () => {
+      const place = autocomplete.getPlace();
+
+      if (!place.geometry || !place.geometry.location) {
+        console.error('No geometry found for selected place');
+        return;
+      }
+
+      const placeDetails: PlaceDetails = {
+        address: place.formatted_address || '',
+        latitude: place.geometry.location.lat(),
+        longitude: place.geometry.location.lng(),
+        name: place.name
+      };
+
+      onPlaceSelect(placeDetails);
+
+      // Create new session token for next search
+      if (places) {
+        setSessionToken(new places.AutocompleteSessionToken());
+      }
+    });
+
+    return () => {
+      // Cleanup
+      google.maps.event.clearInstanceListeners(autocomplete);
+    };
+  }, [places, onPlaceSelect]);
+
+  if (!places) {
+    return (
+      <div className="relative">
+        <Input
+          disabled
+          placeholder="Loading Places API..."
+          className="pl-10"
+        />
+        <div className="absolute left-3 top-1/2 -translate-y-1/2">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        ref={inputRef}
+        type="text"
+        placeholder={placeholder}
+        defaultValue={value}
+        disabled={disabled}
+        className="pl-10"
+      />
+      <div className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
+        <MapPin className="h-4 w-4 text-muted-foreground" />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
-import { apiClient, BookingRequest, BookingUpdateRequest, Dog, DogRequest, OwnerProfileRequest } from '../lib/api-client';
+import { apiClient, BookingRequest, BookingUpdateRequest, Dog, DogRequest, OwnerProfileRequest, VenueRequest, VenueResponse } from '../lib/api-client';
 
 // Query Keys
 export const QueryKeys = {
@@ -238,6 +238,22 @@ export function useCancelBooking() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QueryKeys.bookings });
+    },
+  });
+}
+
+export function useCreateVenue() {
+  const { getIdToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation<VenueResponse, Error, VenueRequest>({
+    mutationFn: async (data: VenueRequest) => {
+      const token = await getIdToken();
+      if (!token) throw new Error('No auth token');
+      return apiClient.createVenue(data, token);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QueryKeys.venues });
     },
   });
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -13,7 +13,11 @@ export type BookingResponse = components['schemas']['BookingResponse'];
 export type BookingListResponse = components['schemas']['BookingListResponse'];
 export type BookingUpdateRequest = components['schemas']['BookingUpdateRequest'];
 export type VenueResponse = components['schemas']['VenueResponse'];
+export type VenueRequest = components['schemas']['VenueRequest'];
 export type VenueListResponse = components['schemas']['VenueListResponse'];
+export type ServiceType = components['schemas']['ServiceType'];
+export type OperatingHours = components['schemas']['OperatingHours'];
+export type DayHours = components['schemas']['DayHours'];
 export type ErrorResponse = components['schemas']['ErrorResponse'];
 
 class ApiClient {
@@ -77,6 +81,13 @@ class ApiClient {
     const params = new URLSearchParams({ start_date: startDate });
     if (endDate) params.append('end_date', endDate);
     return this.request(`/slots/venue/${venueId}?${params.toString()}`);
+  }
+
+  async createVenue(data: VenueRequest, token: string): Promise<VenueResponse> {
+    return this.request<VenueResponse>('/venues', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }, token);
   }
 
   // Protected endpoints (auth required)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to add venues directly from the map view, including a modal form for venue details and integration with the Google Places API for address autocomplete. It also adds supporting API, types, and hooks for venue creation, and updates the UI to display the new functionality.

**Feature: Add Venue Modal & Map Integration**
- Adds a new `AddVenueModal` component with a comprehensive form for venue creation, including name, address (with Google Places autocomplete), coordinates, capacity, services, and operating hours.
- Integrates the venue creation modal as a floating button in the `MapView` component, allowing users to add venues directly from the map.

**API & Type Support**
- Implements a new API method `createVenue` in `api-client.ts` for submitting venue data to the backend, and exposes related types (`VenueRequest`, `ServiceType`, `DayHours`, etc.). [[1]](diffhunk://#diff-60e79904f1b7c808f99a0ace813aaaa4509d813c85c0bc927d3294c000bbeb6fR16-R20) [[2]](diffhunk://#diff-60e79904f1b7c808f99a0ace813aaaa4509d813c85c0bc927d3294c000bbeb6fR86-R92)
- Adds a React Query mutation hook `useCreateVenue` for handling venue creation and refreshing the venue list after submission.

**UI/UX Enhancements**
- Introduces the `PlaceAutocompleteInput` component, providing Google Places-powered address search and selection, restricted to UK addresses.
- Updates `MapView.tsx` to use the new modal and mutation, and provides user feedback (success/error toasts) upon venue creation attempts. [[1]](diffhunk://#diff-e358f34a0d8c80114de226f5912bbdaa70a7d91f1a4ced8521afd95a92db145dR23-R48) [[2]](diffhunk://#diff-e358f34a0d8c80114de226f5912bbdaa70a7d91f1a4ced8521afd95a92db145dL5-R14)